### PR TITLE
Add/modified destructors to tear down model properly

### DIFF
--- a/include/AccessorFramework/Accessor.h
+++ b/include/AccessorFramework/Accessor.h
@@ -60,6 +60,9 @@ protected:
     // Clears the callback with the given ID
     void ClearScheduledCallback(int callbackId);
 
+    // Clears all callbacks for this Accessor
+    void ClearAllScheduledCallbacks();
+
     // Port names cannot be empty, and an accessor can have only one port with a given name
     bool NewPortNameIsValid(const std::string& newPortName) const;
 
@@ -97,6 +100,8 @@ protected:
     // Child names cannot be empty or the same as the parent's name, and a parent can have only one child with a given name
     bool NewChildNameIsValid(const std::string& newChildName) const;
     void AddChild(std::unique_ptr<Accessor> child);
+    void RemoveChild(const std::string& childName);
+    void RemoveAllChildren();
     void ConnectMyInputToChildInput(const std::string& myInputPortName, const std::string& childName, const std::string& childInputPortName);
     void ConnectChildOutputToMyOutput(const std::string& childName, const std::string& childOutputPortName, const std::string& myOutputPortName);
     void ConnectChildren(

--- a/src/Accessor.cpp
+++ b/src/Accessor.cpp
@@ -45,6 +45,11 @@ void Accessor::ClearScheduledCallback(int callbackId)
     this->m_impl->ClearScheduledCallback(callbackId);
 }
 
+void Accessor::ClearAllScheduledCallbacks()
+{
+    this->m_impl->ClearAllScheduledCallbacks();
+}
+
 bool Accessor::NewPortNameIsValid(const std::string& newPortName) const
 {
     return this->m_impl->NewPortNameIsValid(newPortName);
@@ -110,6 +115,16 @@ bool CompositeAccessor::NewChildNameIsValid(const std::string& newChildName) con
 void CompositeAccessor::AddChild(std::unique_ptr<Accessor> child)
 {
     static_cast<CompositeAccessor::Impl*>(this->GetImpl())->AddChild(std::move(child));
+}
+
+void CompositeAccessor::RemoveChild(const std::string& childName)
+{
+    static_cast<CompositeAccessor::Impl*>(this->GetImpl())->RemoveChild(childName);
+}
+
+void CompositeAccessor::RemoveAllChildren()
+{
+    static_cast<CompositeAccessor::Impl*>(this->GetImpl())->RemoveAllChildren();
 }
 
 void CompositeAccessor::ConnectMyInputToChildInput(const std::string& myInputPortName, const std::string& childName, const std::string& childInputPortName)

--- a/src/AccessorImpl.cpp
+++ b/src/AccessorImpl.cpp
@@ -8,7 +8,10 @@
 
 const int Accessor::Impl::DefaultAccessorPriority = INT_MAX;
 
-Accessor::Impl::~Impl() = default;
+Accessor::Impl::~Impl()
+{
+    this->ClearAllScheduledCallbacks();
+}
 
 bool Accessor::Impl::IsInitialized() const
 {
@@ -113,7 +116,8 @@ int Accessor::Impl::ScheduleCallback(
     int delayInMilliseconds,
     bool repeat)
 {
-    int callbackId = this->GetDirector()->ScheduleCallback(
+    auto director = this->GetDirector();
+    int callbackId = director->ScheduleCallback(
         callback,
         delayInMilliseconds,
         repeat,
@@ -124,8 +128,22 @@ int Accessor::Impl::ScheduleCallback(
 
 void Accessor::Impl::ClearScheduledCallback(int callbackId)
 {
-    this->GetDirector()->ClearScheduledCallback(callbackId);
+    auto director = this->GetDirector();
+    if (director.get() != nullptr)
+    {
+        director->ClearScheduledCallback(callbackId);
+    }
+
     this->m_callbackIds.erase(callbackId);
+}
+
+void Accessor::Impl::ClearAllScheduledCallbacks()
+{
+    while (!this->m_callbackIds.empty())
+    {
+        int callbackId = *(this->m_callbackIds.begin());
+        this->ClearScheduledCallback(callbackId);
+    }
 }
 
 bool Accessor::Impl::NewPortNameIsValid(const std::string& newPortName) const

--- a/src/AccessorImpl.h
+++ b/src/AccessorImpl.h
@@ -40,6 +40,7 @@ protected:
     // Accessor Methods
     int ScheduleCallback(std::function<void()> callback, int delayInMilliseconds, bool repeat);
     void ClearScheduledCallback(int callbackId);
+    void ClearAllScheduledCallbacks();
     bool NewPortNameIsValid(const std::string& newPortName) const;
     virtual void AddInputPort(const std::string& portName);
     virtual void AddInputPorts(const std::vector<std::string>& portNames);

--- a/src/CompositeAccessorImpl.h
+++ b/src/CompositeAccessorImpl.h
@@ -24,7 +24,7 @@ public:
         std::function<void(Accessor&)> initializeFunction,
         const std::vector<std::string>& inputPortNames = {},
         const std::vector<std::string>& connectedOutputPortNames = {});
-
+    ~Impl();
     bool HasChildWithName(const std::string& childName) const;
     Accessor::Impl* GetChild(const std::string& childName) const;
     std::vector<Accessor::Impl*> GetChildren() const;
@@ -39,6 +39,8 @@ protected:
     // CompositeAccessor Methods
     bool NewChildNameIsValid(const std::string& newChildName) const;
     void AddChild(std::unique_ptr<Accessor> child);
+    void RemoveChild(const std::string& childName);
+    void RemoveAllChildren();
     void ConnectMyInputToChildInput(const std::string& myInputPortName, const std::string& childName, const std::string& childInputPortName);
     void ConnectChildOutputToMyOutput(const std::string& childName, const std::string& childOutputPortName, const std::string& myOutputPortName);
     void ConnectChildren(

--- a/src/Director.cpp
+++ b/src/Director.cpp
@@ -23,7 +23,7 @@ Director::Director() :
 
 Director::~Director()
 {
-    this->CancelNextExecution();
+    this->Reset();
 }
 
 int Director::ScheduleCallback(

--- a/src/Port.h
+++ b/src/Port.h
@@ -27,6 +27,7 @@ class Port : public BaseObject
 {
 public:
     Port(const std::string& name, Accessor::Impl* owner);
+    ~Port();
     Accessor::Impl* GetOwner() const;
     virtual bool IsSpontaneous() const;
     bool IsConnectedToSource() const;
@@ -37,6 +38,8 @@ public:
     virtual void ReceiveData(std::shared_ptr<IEvent> data) = 0;
 
     static void Connect(Port* source, Port* destination);
+    static void Disconnect(Port* source, Port* destination);
+    static void DisconnectAll(Port* port);
 
 private:
     static void ValidateConnection(Port* source, Port* destination);


### PR DESCRIPTION
Added/modified Accessor destructors to clear all scheduled callbacks and destroy children in order to avoid dangling references. Added Port destructors to disconnect on destruction.